### PR TITLE
MIN-000: Typo fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 A changelog for logging changes.
 
-## 0.0.133
+## 0.0.134
 - Fix bug with iOS zoom on `<mid-code-input>`
 - Change auto-submit of WebOTP to trigger on 'mid-complete' event.
 - Added inputmode control to `<mid-textfield>`

--- a/src/stories/Textfield.stories.ts
+++ b/src/stories/Textfield.stories.ts
@@ -91,17 +91,18 @@ const meta = {
         'url',
         'week',
       ],
-      inputmode: {
-        control: { type: 'select' },
-        options: [
-          'none',
-          'text',
-          'tel',
-          'url',
-          'email',
-          'numeric',
-          'decimal'
-        ],
+    },
+    inputmode: {
+      control: { type: 'select' },
+      options: [
+        'none',
+        'text',
+        'tel',
+        'url',
+        'email',
+        'numeric',
+        'decimal'
+      ],
     },
     pattern: { type: 'string' },
     mask: { type: 'string' },


### PR DESCRIPTION
- Fix bug with iOS zoom on `<mid-code-input>`
- Change auto-submit of WebOTP to trigger on 'mid-complete' event.
- Added inputmode control to `<mid-textfield>`