### PR TITLE
MIN-2503 code input filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 A changelog for logging changes.
 
+## 0.0.138
+- Bug fix, in the code input number field, numbers disappear when non number is written
+
 ## 0.0.137
 - Form control's `#touched` is set true when altered instead of focused.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felleslosninger/minid-elements",
-  "version": "0.0.136",
+  "version": "0.0.137",
   "description": "MinID Web Components",
   "author": "Digitaliseringsdirektoratet",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felleslosninger/minid-elements",
-  "version": "0.0.135",
+  "version": "0.0.136",
   "description": "MinID Web Components",
   "author": "Digitaliseringsdirektoratet",
   "license": "MIT",

--- a/src/components/code-input.component.ts
+++ b/src/components/code-input.component.ts
@@ -241,13 +241,17 @@ export class MinidCodeInput extends FormControlMixin(
     this.isFocused = false;
   }
 
+  private handleBeforeInput(e: InputEvent) {
+    if (e.inputType === 'insertText' && e.data) {
+      if(this.type == "number" && e.data.replace(/\D/g, '') == ''){
+        e.preventDefault();
+      }
+    }
+  }
+
   private handleInput(event: InputEvent) {
     const input = event.target as HTMLInputElement;
     let value = input.value;
-
-    if (this.type === 'number') {
-      value = value.replace(/[^0-9]/g, '');
-    }
 
     value = value.substring(0, this.length);
 
@@ -396,6 +400,7 @@ export class MinidCodeInput extends FormControlMixin(
           .pattern="${this.pattern}"
           inputmode="${this.inputmode}"
           autocomplete="one-time-code"
+          @beforeinput="${this.handleBeforeInput}"
           @input="${this.handleInput}"
           @change="${this.handleChange}"
           @keydown="${this.handleKeydown}"

--- a/src/stories/CodeInput.stories.ts
+++ b/src/stories/CodeInput.stories.ts
@@ -9,7 +9,7 @@ type CodeInputProps = Partial<{
   value: string;
   label: string;
   labelAttr: string;
-  allowedtype: 'digits' | 'alphanumeric' | 'any';
+  type: 'number' | 'text';
   size: 'sm' | 'md' | 'lg';
   inputmode: 'numeric' | 'text';
   invalidmessage: string;
@@ -39,7 +39,7 @@ const meta = {
     pattern: { type: 'string' },
     minlength: { type: 'number' },
     size: { control: 'radio', options: ['sm', 'md', 'lg'] },
-    allowedtype: { control: 'radio', options: ['digits', 'alphanumeric', 'any'] },
+    type: { control: 'radio', options: ['number', 'text'] },
     inputmode: { control: 'radio', options: ['numeric', 'text'] },
     labelAttr: {
       name: 'label',
@@ -81,7 +81,7 @@ export const Main: Story = {
     value,
     label,
     labelAttr,
-    allowedtype,
+    type,
     size,
     autofocus,
     disabled,
@@ -96,7 +96,7 @@ export const Main: Story = {
         label=${ifDefined(labelAttr)}
         length=${ifDefined(length)}
         minlength=${ifDefined(minlength)}
-        allowedtype=${ifDefined(allowedtype)}
+        type=${ifDefined(type)}
         size=${ifDefined(size)}
         inputmode=${ifDefined(inputmode)}
         invalidmessage=${ifDefined(invalidmessage)}


### PR DESCRIPTION
Chagnes:
- Added allowed types of digits, alphanumericas and any to code field.
- Digits dont disappear when a character is entered.
- Field type changed to text to avoid behavior with math.
- Type any should allow IME, but not tested nor probably going to be used.