### PR TITLE
MIN-2900 small fix for screen readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 A changelog for logging changes.
 
+## 0.0.139
+Minor improvements:
+ - Screen readers:
+    - Code Input "○" is now hidden for screen readers.
+    - Text field and Code Input @mid-invalid-show will be read by the screen reader.
+    - Phone Input now has internal invalidMessage that will display under the field. Also focus no longer highlight the text to compensate for screen readers.
+    - Icons are no longer read as image by screen readers.
+ - Minor fixes
+   - Code Field focus highlight will be kept on last square so the user don't lose focus.
 ## 0.0.138
 - Bug fix, in the code input number field, numbers disappear when non number is written
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felleslosninger/minid-elements",
-  "version": "0.0.138",
+  "version": "0.0.139",
   "description": "MinID Web Components",
   "author": "Digitaliseringsdirektoratet",
   "license": "MIT",

--- a/src/components/code-input.component.ts
+++ b/src/components/code-input.component.ts
@@ -1,6 +1,7 @@
 import { css, html, LitElement, PropertyValues } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { live } from 'lit/directives/live.js';
 import { watch } from '../internal/watch.ts';
 import { FormControlMixin } from '../mixins/form-control.mixin.ts';
@@ -131,6 +132,7 @@ export class MinidCodeInput extends FormControlMixin(
 ) {
   private readonly hasSlotControler = new HasSlotController(this, 'label');
   private readonly labelId = `mid-code-input-label-${nextUniqueId++}`;
+  private readonly validationId = `mid-code-input-validation-${nextUniqueId++}`;
 
   @query('.hidden-input')
   private inputElement!: HTMLInputElement;
@@ -329,13 +331,18 @@ export class MinidCodeInput extends FormControlMixin(
   override render() {
     const hasLabelSlot = this.hasSlotControler.test('label');
     const hasLabel = !!this.label || !!hasLabelSlot;
+    const describedBy = this.invalidmessage ? this.validationId : undefined;
 
     const chars = this.value.split('');
     const displayValues = Array.from(
       { length: this.length },
       (_, i) => chars[i] || '',
     );
-    const caretIndex = this.disabled ? -1 : this.value.length;
+    const isComplete = this.value.length >= this.length;
+    const caretIndex =
+      this.disabled || this.length === 0
+        ? -1
+        : Math.min(this.value.length, this.length - 1);
 
     return html`
       <label
@@ -357,9 +364,10 @@ export class MinidCodeInput extends FormControlMixin(
     })}"
         @click=${() => this.focus()}
       >
-        <div part="character-boxes" class="character-boxes">
+        <div part="character-boxes" class="character-boxes" aria-hidden="true">
           ${displayValues.map((char, index) => {
-      const hasCaret = this.isFocused && index === caretIndex;
+      const isFocusTarget = this.isFocused && index === caretIndex;
+      const hasCaret = isFocusTarget && !isComplete;
       return html`
               <div
                 part="character-box"
@@ -375,7 +383,7 @@ export class MinidCodeInput extends FormControlMixin(
         'text-danger-surface-active': !char && this.invalidmessage,
         'character-box--caret': hasCaret,
         'character-box--empty': !char,
-        'focus-ring-sm': hasCaret,
+        'focus-ring-sm': isFocusTarget,
       })} size-9 rounded-md text-center font-mono"
                 @click=${(e: MouseEvent) => {
         e.stopPropagation();
@@ -393,6 +401,11 @@ export class MinidCodeInput extends FormControlMixin(
           id="mid-code-input-hidden"
           type="${this.type}"
           aria-labelledby="${this.labelId}"
+          aria-describedby=${ifDefined(describedBy)}
+          aria-invalid=${this.invalidmessage ? 'true' : 'false'}
+          aria-errormessage=${ifDefined(
+            this.invalidmessage ? this.validationId : undefined
+          )}
           maxlength="${this.length}"
           ?autofocus="${this.autofocus}"
           ?disabled="${this.disabled}"
@@ -410,6 +423,7 @@ export class MinidCodeInput extends FormControlMixin(
       </div>
       <div
         class="text-danger-subtle mt-2 flex gap-1"
+        id="${this.validationId}"
         aria-live="polite"
         ?hidden=${!this.invalidmessage}
       >

--- a/src/components/icon/icon.component.ts
+++ b/src/components/icon/icon.component.ts
@@ -83,6 +83,18 @@ export class MinidIcon extends styled(LitElement, styles) {
 
   private hasRendered = false;
 
+  private updateAccessibilityAttributes() {
+    if (typeof this.alt === 'string' && this.alt.length > 0) {
+      this.setAttribute('role', 'img');
+      this.setAttribute('aria-label', this.alt);
+      this.removeAttribute('aria-hidden');
+    } else {
+      this.removeAttribute('role');
+      this.removeAttribute('aria-label');
+      this.setAttribute('aria-hidden', 'true');
+    }
+  }
+
   /**
    * Given a URL, this function returns the resulting SVG element or an appropriate error symbol.
    */
@@ -134,20 +146,13 @@ export class MinidIcon extends styled(LitElement, styles) {
 
   firstUpdated() {
     this.hasRendered = true;
+    this.updateAccessibilityAttributes();
     this.setIcon();
   }
 
   @watch('alt')
   handleLabelChange() {
-    if (typeof this.alt === 'string' && this.alt.length > 0) {
-      this.setAttribute('role', 'img');
-      this.setAttribute('aria-label', this.alt);
-      this.removeAttribute('aria-hidden');
-    } else {
-      this.removeAttribute('role');
-      this.removeAttribute('aria-label');
-      this.setAttribute('aria-hidden', 'true');
-    }
+    this.updateAccessibilityAttributes();
   }
 
   @watch(['name', 'src', 'library'])

--- a/src/components/phone-input.component.ts
+++ b/src/components/phone-input.component.ts
@@ -1,6 +1,7 @@
 import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { styled } from '../mixins/tailwind.mixin';
 import {
   AsYouType,
@@ -35,6 +36,8 @@ const styles = [
   `,
 ];
 
+let nextUniqueId = 0;
+
 /**
  * @event {Event} mid-country-click - Emitted when the country button is clicked
  * @event {Event} mid-change - Emitted when the value is modified by the user
@@ -52,13 +55,16 @@ const styles = [
 export class MinidPhoneInput extends FormControlMixin(
   styled(LitElement, styles)
 ) {
+  private readonly inputId: string;
+  private readonly validationId: string;
+  private readonly labelId = `mid-code-input-label-${nextUniqueId++}`;
   private formatter = new AsYouType();
   private skipCountryUpdate = false; // avoids unwanted update loop
   private currentEvent = new Event(''); // the event to be emitted after value is set
   private currentTemplate = '';
   private hasSlotControler = new HasSlotController(this, 'label');
 
-  @query('#input')
+  @query('input')
   input!: HTMLInputElement;
 
   /**
@@ -106,6 +112,12 @@ export class MinidPhoneInput extends FormControlMixin(
   invalid = false;
 
   /**
+   * Error message to display when the input is invalid, also activates invalid styling
+   */
+  @property()
+  invalidmessage = '';
+
+  /**
    * Makes the input required
    */
   @property({ type: Boolean })
@@ -122,6 +134,25 @@ export class MinidPhoneInput extends FormControlMixin(
 
   static get formControlValidators() {
     return [requiredValidator];
+  }
+
+  constructor() {
+    super();
+    nextUniqueId++;
+    this.inputId = `mid-phone-input-input-${nextUniqueId}`;
+    this.validationId = `mid-phone-input-validation-${nextUniqueId}`;
+  }
+
+  get validationTarget() {
+    return this.input;
+  }
+
+  validationMessageCallback(message: string) {
+    this.invalidmessage = message;
+  }
+
+  resetFormControl() {
+    this.invalidmessage = '';
   }
 
   handleCountryClick() {
@@ -282,14 +313,8 @@ export class MinidPhoneInput extends FormControlMixin(
     return value;
   }
 
-  focus() {
-    this.input.focus();
-    setTimeout(() => {
-      this.input.setSelectionRange(
-        (this.countrycode?.length ?? 0) + 1,
-        this.input.value.length
-      );
-    }, 0);
+  focus(options?: FocusOptions): void {
+    this.input.focus(options);
   }
 
   @watch('country', { waitUntilFirstUpdate: true })
@@ -319,8 +344,16 @@ export class MinidPhoneInput extends FormControlMixin(
 
     const hasLabelSlot = this.hasSlotControler.test('label');
     const hasLabel = !!this.label || !!hasLabelSlot;
+    const hasError = this.invalid || !!this.invalidmessage;
+    const describedBy = this.invalidmessage ? this.validationId : undefined;
 
     return html`
+      <label
+        id="${this.labelId}"
+        class="${classMap({
+          'sr-only': this.hidelabel || !hasLabel,
+        })} mb-2 block items-center gap-1 font-medium"
+      > 
       <div
         part="field"
         class="${classMap({
@@ -330,7 +363,7 @@ export class MinidPhoneInput extends FormControlMixin(
         })}"
       >
         <label
-          for="input"
+          for="${this.inputId}"
           class="${classMap({
             'sr-only': this.hidelabel || !hasLabel,
           })} mb-2 inline-flex items-center gap-1 font-medium"
@@ -375,27 +408,44 @@ export class MinidPhoneInput extends FormControlMixin(
           </button>
 
           <input
-            id="input"
+            id="${this.inputId}"
             class="${classMap({
-              'border-neutral': !this.invalid && !this.readonly,
-              'border-danger': this.invalid && !this.readonly,
+              'border-neutral': !hasError && !this.readonly,
+              'border-danger': hasError && !this.readonly,
               'border-neutral-subtle': this.readonly,
               'bg-neutral-surface-tinted': this.readonly,
               'bg-neutral-surface': !this.readonly,
-              'border-2': this.invalid,
-              border: !this.invalid,
+              'border-2': hasError,
+              border: !hasError,
             })} focus-visible:focus-ring grow rounded-r px-3"
             part="phone-number"
             type="tel"
             autocomplete="tel"
             ?readonly=${this.readonly}
             value=${this.value}
+            aria-describedby=${ifDefined(describedBy)}
+            aria-invalid=${hasError ? 'true' : 'false'}
+            aria-errormessage=${ifDefined(
+              this.invalidmessage ? this.validationId : undefined
+            )}
             @input=${this.handleInput}
             @focus=${this.handleFocus}
             @blur=${this.handleBlur}
             @keydown=${this.handleKeydown}
             @change=${this.handleChange}
           />
+        </div>
+        <div
+          class="text-danger-subtle mt-2 flex gap-1"
+          id="${this.validationId}"
+          aria-live="polite"
+          ?hidden=${!this.invalidmessage}
+        >
+          <mid-icon
+            name="xmark-octagon-fill"
+            class="mt-1 min-h-5 min-w-5"
+          ></mid-icon>
+          ${this.invalidmessage}
         </div>
       </div>
     `;

--- a/src/components/textfield.component.ts
+++ b/src/components/textfield.component.ts
@@ -362,6 +362,12 @@ export class MinidTextfield extends FormControlMixin(
     const hasClearIcon = this.clearable && !this.disabled && !this.readonly;
     const isClearIconVisible =
       hasClearIcon && (typeof this.value === 'number' || this.value.length > 0);
+    const describedBy = [
+      this.description ? this.descriptionId : undefined,
+      this.invalidmessage ? this.validationId : undefined,
+    ]
+      .filter(Boolean)
+      .join(' ');
 
     return html`
       <div
@@ -433,10 +439,11 @@ export class MinidTextfield extends FormControlMixin(
             type=${this.type === 'password' && this.passwordvisible
               ? 'text'
               : this.type}
-            aria-describedby="${ifDefined(
-              (this.description && this.descriptionId) || undefined
-            )}"
-            aria-errormessage="${this.validationId}"
+            aria-describedby=${ifDefined(describedBy || undefined)}
+            aria-invalid=${this.invalidmessage ? 'true' : 'false'}
+            aria-errormessage=${ifDefined(
+              this.invalidmessage ? this.validationId : undefined
+            )}
             placeholder=${ifDefined(this.placeholder)}
             minlength=${ifDefined(this.minlength)}
             maxlength=${ifDefined(this.maxlength)}


### PR DESCRIPTION
Small changes to make it work better for screen readers.

Whats new:
## 0.0.139
Minor improvements:
 - Screen readers:
    - Code Input "○" is now hidden for screen readers.
    - Text field and Code Input @mid-invalid-show will be read by the screen reader.
    - Phone Input now has internal invalidMessage that will display under the field. Also focus no longer highlight the text to compensate for screen readers.
    - Icons are no longer read as image by screen readers.
 - Minor fixes
   - Code Field focus highlight will be kept on last square so the user don't lose focus.
