### PR TITLE
chore(alert): hide icon for screen readers

### DIFF
--- a/src/components/alert.component.ts
+++ b/src/components/alert.component.ts
@@ -3,7 +3,6 @@ import { customElement, property, query, state } from 'lit/decorators.js';
 import { classMap } from 'lit/directives/class-map.js';
 import { styled } from '../mixins/tailwind.mixin.ts';
 import './icon/icon.component';
-import { ifDefined } from 'lit/directives/if-defined.js';
 import { watch } from '../internal/watch';
 import {
   getAnimation,

--- a/src/components/alert.component.ts
+++ b/src/components/alert.component.ts
@@ -328,7 +328,7 @@ export class MinidAlert extends styled(LitElement) {
           })} size-7"
           name="${iconName}"
           library="system"
-          alt=${ifDefined(this.iconlabel)}
+          aria-hidden="true"
         ></mid-icon>
         <div aria-live="polite">
           <slot>


### PR DESCRIPTION
The text in the alert should be sufficent enough for people to understand the context.
An alert which needs to be read out will also need proper attrs set, making the icon name redundant