### PR TITLE
96 lang handling

### DIFF
--- a/src/components/search.component.ts
+++ b/src/components/search.component.ts
@@ -4,6 +4,9 @@ import { styled } from '../mixins/tailwind.mixin';
 import { live } from 'lit/directives/live.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { debounce } from '../internal/debounce.ts';
+import { getLang } from '../utilities/lang';
+import { getTranslations } from '../utilities/translations';
+import { LangController } from '../controllers/lang.controller.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -32,6 +35,11 @@ const styles = [
  */
 @customElement('mid-search')
 export class MinidSearch extends styled(LitElement, styles) {
+  constructor() {
+    super();
+    new LangController(this);
+  }
+
   @query('input')
   input!: HTMLInputElement;
 
@@ -94,8 +102,10 @@ export class MinidSearch extends styled(LitElement, styles) {
   }
 
   override render() {
+    const lang = getLang(this);
+    const t = getTranslations(lang);
     return html`
-    <ds-field class="ds-field">
+    <ds-field class="ds-field" lang=${lang}>
       ${this.label
         ? html`<label class="ds-label mb-2">${this.label}</label>`
         : nothing}
@@ -120,7 +130,7 @@ export class MinidSearch extends styled(LitElement, styles) {
           data-icon="true"
           data-variant="tertiary"
           type="reset"
-          aria-label="Tøm"
+          aria-label=${t.clear}
           @click=${this.handleClear}
         ></button>
       </div>

--- a/src/components/textfield.component.ts
+++ b/src/components/textfield.component.ts
@@ -31,7 +31,7 @@ const styles = [
     :host {
       display: block;
     }
-      
+
     /* Hide increment/decrement buttons on inputs */
     input[type='number']::-webkit-outer-spin-button,
     input[type='number']::-webkit-inner-spin-button,
@@ -39,6 +39,10 @@ const styles = [
         -webkit-appearance: none;
         margin: 0;
         -moz-appearance: textfield !important;
+    }
+
+    .ds-field-affixes {
+      background: var(--ds-color-neutral-background-tinted);
     }
   `,
 ];
@@ -356,8 +360,8 @@ export class MinidTextfield extends FormControlMixin(styled(LitElement, styles))
     const hasLabel = !!this.label || !!hasLabelSlot;
     const hasPrefix = this.hasSlotControler.test('prefix');
     const hasSuffix = this.hasSlotControler.test('suffix');
-    const hasAffixes = hasPrefix || hasSuffix;
     const hasClearIcon = this.clearable && !this.disabled && !this.readonly;
+    const hasAffixes = hasPrefix || hasSuffix || hasClearIcon || (this.passwordtoggle && !this.disabled);
     const isClearIconVisible =
       hasClearIcon && (typeof this.value === 'number' || this.value.length > 0);
     const describedBy = [
@@ -379,13 +383,6 @@ export class MinidTextfield extends FormControlMixin(styled(LitElement, styles))
             'sr-only': this.hidelabel || !hasLabel,
           })} ds-label"
         >
-          ${this.readonly
-            ? html`<mid-icon
-                class="size-5"
-                library="system"
-                name="padlock-locked-fill"
-              ></mid-icon>`
-            : nothing}
           <slot name="label"> ${this.label} </slot>
         </label>
         ${this.description
@@ -440,47 +437,49 @@ export class MinidTextfield extends FormControlMixin(styled(LitElement, styles))
           />
           ${isClearIconVisible
             ? html`
-                <button
-                  part="clear-button"
-                  type="button"
-                  class="focus-visible:focus-ring ml-2 flex items-center justify-center rounded-sm"
-                  aria-label=${t.clear}
-                  @click=${this.handleClearClick}
-                >
-                  <mid-icon
-                    class="size-7"
-                    library="system"
-                    name="xmark"
-                  ></mid-icon>
-                </button>
+                <span class="ds-field-affix" part="clear-button">
+                  <button
+                    type="button"
+                    class="focus-visible:focus-ring flex items-center justify-center rounded-sm"
+                    aria-label=${t.clear}
+                    @click=${this.handleClearClick}
+                  >
+                    <mid-icon
+                      class="size-7"
+                      library="nav-aksel"
+                      name="trash"
+                    ></mid-icon>
+                  </button>
+                </span>
               `
             : ''}
           ${this.passwordtoggle && !this.disabled
             ? html`
-                <button
-                  part="password-toggle-button"
-                  type="button"
-                  class="ml-2 flex items-center justify-center rounded-sm"
-                  aria-label=${this.passwordvisible
-                    ? t.hidePassword
-                    : t.showPassword}
-                  @click=${this.handlePasswordToggle}
-                  tabindex="-1"
-                >
-                  ${this.passwordvisible
-                    ? html` <mid-icon
-                        class="size-7"
-                        library="system"
-                        name="eye-slash"
-                      ></mid-icon>`
-                    : html`
-                        <mid-icon
+                <span class="ds-field-affix" part="password-toggle-button">
+                  <button
+                    type="button"
+                    class="flex items-center justify-center rounded-sm"
+                    aria-label=${this.passwordvisible
+                      ? t.hidePassword
+                      : t.showPassword}
+                    @click=${this.handlePasswordToggle}
+                    tabindex="-1"
+                  >
+                    ${this.passwordvisible
+                      ? html` <mid-icon
                           class="size-7"
                           library="system"
-                          name="eye"
-                        ></mid-icon>
-                      `}
-                </button>
+                          name="eye-slash"
+                        ></mid-icon>`
+                      : html`
+                          <mid-icon
+                            class="size-7"
+                            library="system"
+                            name="eye"
+                          ></mid-icon>
+                        `}
+                  </button>
+                </span>
               `
             : ''}
           ${hasSuffix ? html`<span part="suffix" class="ds-field-affix"><slot name="suffix"></slot></span>` : html`<slot name="suffix"></slot>`}

--- a/src/components/textfield.component.ts
+++ b/src/components/textfield.component.ts
@@ -16,6 +16,9 @@ import {
 import { watch } from '../internal/watch';
 import './icon/icon.component.ts';
 import { MaskInput, type MaskType } from 'maska';
+import { getLang } from '../utilities/lang';
+import { getTranslations } from '../utilities/translations';
+import { LangController } from '../controllers/lang.controller.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -63,9 +66,7 @@ let nextUniqueId = 0;
  * @csspart password-toggle-button - The button for toggling password visibility
  */
 @customElement('mid-textfield')
-export class MinidTextfield extends FormControlMixin(
-  styled(LitElement, styles)
-) {
+export class MinidTextfield extends FormControlMixin(styled(LitElement, styles)) {
   private readonly inputId!: string;
   private readonly descriptionId!: string;
   private readonly validationId!: string;
@@ -73,7 +74,7 @@ export class MinidTextfield extends FormControlMixin(
   private inputMask?: MaskInput;
   private initialValue = '';
 
-  @query('.input')
+  @query('input')
   input!: HTMLInputElement;
 
   @property()
@@ -135,7 +136,7 @@ export class MinidTextfield extends FormControlMixin(
 
   @property()
   type:
-    'date'
+    | 'date'
     | 'datetime-local'
     | 'email'
     | 'file'
@@ -154,7 +155,7 @@ export class MinidTextfield extends FormControlMixin(
    */
   @property()
   inputmode:
-    'none'
+    | 'none'
     | 'text'
     | 'tel'
     | 'url'
@@ -164,7 +165,7 @@ export class MinidTextfield extends FormControlMixin(
 
   /**
    * Adds a clear button when the input is not empty.
-   * */
+   */
   @property({ type: Boolean })
   clearable = false;
 
@@ -230,6 +231,7 @@ export class MinidTextfield extends FormControlMixin(
 
   constructor() {
     super();
+    new LangController(this);
     nextUniqueId++;
     this.inputId = `mid-textfield-input-${nextUniqueId}`;
     this.descriptionId = `mid-textfield-description-${nextUniqueId}`;
@@ -250,13 +252,8 @@ export class MinidTextfield extends FormControlMixin(
     const hasModifier =
       event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
 
-    // Pressing enter when focused on an input should submit the form like a native input, but we wait a tick before
-    // submitting to allow users to cancel the keydown event if they need to
     if (event.key === 'Enter' && !hasModifier) {
       setTimeout(() => {
-        //
-        // When using an Input Method Editor (IME), pressing enter will cause the form to submit unexpectedly. One way
-        // to check for this is to look at event.isComposing, which will be true when the IME is open.
         if (!event.defaultPrevented && !event.isComposing) {
           this.form.requestSubmit();
         }
@@ -353,6 +350,8 @@ export class MinidTextfield extends FormControlMixin(
   }
 
   override render() {
+    const lang = getLang(this);
+    const t = getTranslations(lang);
     const hasLabelSlot = this.hasSlotControler.test('label');
     const hasLabel = !!this.label || !!hasLabelSlot;
     const hasPrefix = this.hasSlotControler.test('prefix');
@@ -412,6 +411,7 @@ export class MinidTextfield extends FormControlMixin(
             id="${this.inputId}"
             class="ds-input"
             part="input"
+            lang=${lang}
             .value=${live(this.value)}
             ?disabled=${this.disabled}
             ?readonly=${this.readonly}
@@ -431,6 +431,7 @@ export class MinidTextfield extends FormControlMixin(
             min=${ifDefined(this.min)}
             max=${ifDefined(this.max)}
             pattern=${ifDefined(this.pattern)}
+            inputmode=${this.inputmode}
             @input=${this.handleInput}
             @change=${this.handleChange}
             @focus=${this.handleFocus}
@@ -443,7 +444,7 @@ export class MinidTextfield extends FormControlMixin(
                   part="clear-button"
                   type="button"
                   class="focus-visible:focus-ring ml-2 flex items-center justify-center rounded-sm"
-                  aria-label="Tøm"
+                  aria-label=${t.clear}
                   @click=${this.handleClearClick}
                 >
                   <mid-icon
@@ -461,8 +462,8 @@ export class MinidTextfield extends FormControlMixin(
                   type="button"
                   class="ml-2 flex items-center justify-center rounded-sm"
                   aria-label=${this.passwordvisible
-                    ? 'skjul passord'
-                    : 'vis passord'}
+                    ? t.hidePassword
+                    : t.showPassword}
                   @click=${this.handlePasswordToggle}
                   tabindex="-1"
                 >

--- a/src/controllers/lang.controller.ts
+++ b/src/controllers/lang.controller.ts
@@ -3,19 +3,10 @@ import { getLang } from '../utilities/lang.js';
 
 /**
  * Reactive controller that keeps a component in sync with the active language.
- *
- * Responsibilities:
- * - Sets `lang` on the host element (light DOM) if the consumer hasn't already,
- *   so screen readers (VoiceOver) can detect the language without needing to
- *   traverse into shadow DOM.
- * - Watches `document.documentElement` for `lang` attribute changes (triggered
- *   by `changeLocale`) and calls `host.requestUpdate()` so the shadow DOM
- *   re-renders with the new language.
  */
 export class LangController implements ReactiveController {
   private readonly host: ReactiveControllerHost & HTMLElement;
   private readonly observer: MutationObserver;
-  /** True when we set the host's lang programmatically (not the consumer). */
   private managed = false;
 
   constructor(host: ReactiveControllerHost & HTMLElement) {
@@ -41,12 +32,9 @@ export class LangController implements ReactiveController {
 
   private handleDocumentLangChange() {
     if (this.managed) {
-      // Remove our previously set lang so getLang() walks up to the new
-      // document lang rather than stopping at our stale value on the host.
       this.host.removeAttribute('lang');
       this.host.setAttribute('lang', getLang(this.host));
     }
-    // Always re-render so shadow DOM elements pick up the new lang value.
     this.host.requestUpdate();
   }
 }

--- a/src/controllers/lang.controller.ts
+++ b/src/controllers/lang.controller.ts
@@ -1,0 +1,52 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { getLang } from '../utilities/lang.js';
+
+/**
+ * Reactive controller that keeps a component in sync with the active language.
+ *
+ * Responsibilities:
+ * - Sets `lang` on the host element (light DOM) if the consumer hasn't already,
+ *   so screen readers (VoiceOver) can detect the language without needing to
+ *   traverse into shadow DOM.
+ * - Watches `document.documentElement` for `lang` attribute changes (triggered
+ *   by `changeLocale`) and calls `host.requestUpdate()` so the shadow DOM
+ *   re-renders with the new language.
+ */
+export class LangController implements ReactiveController {
+  private readonly host: ReactiveControllerHost & HTMLElement;
+  private readonly observer: MutationObserver;
+  /** True when we set the host's lang programmatically (not the consumer). */
+  private managed = false;
+
+  constructor(host: ReactiveControllerHost & HTMLElement) {
+    (this.host = host).addController(this);
+    this.observer = new MutationObserver(() => this.handleDocumentLangChange());
+  }
+
+  hostConnected() {
+    if (!this.host.hasAttribute('lang')) {
+      this.host.setAttribute('lang', getLang(this.host));
+      this.managed = true;
+    }
+
+    this.observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['lang'],
+    });
+  }
+
+  hostDisconnected() {
+    this.observer.disconnect();
+  }
+
+  private handleDocumentLangChange() {
+    if (this.managed) {
+      // Remove our previously set lang so getLang() walks up to the new
+      // document lang rather than stopping at our stale value on the host.
+      this.host.removeAttribute('lang');
+      this.host.setAttribute('lang', getLang(this.host));
+    }
+    // Always re-render so shadow DOM elements pick up the new lang value.
+    this.host.requestUpdate();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,3 +29,5 @@ export { MinidValidationMessage } from './components/validation-message.componen
 
 export * from './events/events.ts';
 export * from './utilities/countries.ts';
+export { setTranslations } from './utilities/translations.ts';
+export type { ComponentTranslations } from './utilities/translations.ts';

--- a/src/utilities/lang.ts
+++ b/src/utilities/lang.ts
@@ -1,7 +1,6 @@
 /**
  * Gets the effective language for a given element by walking up the DOM tree,
  * traversing shadow DOM host boundaries along the way.
- * Falls back to the document's `lang` attribute, then `'nb'` (Norwegian Bokmål).
  */
 export function getLang(element: HTMLElement): string {
   let current: Node | null = element;

--- a/src/utilities/lang.ts
+++ b/src/utilities/lang.ts
@@ -1,0 +1,22 @@
+/**
+ * Gets the effective language for a given element by walking up the DOM tree,
+ * traversing shadow DOM host boundaries along the way.
+ * Falls back to the document's `lang` attribute, then `'nb'` (Norwegian Bokmål).
+ */
+export function getLang(element: HTMLElement): string {
+  let current: Node | null = element;
+
+  while (current) {
+    if (current instanceof Element && current.hasAttribute('lang')) {
+      return current.getAttribute('lang')!;
+    }
+    // Cross shadow-DOM host boundary
+    if (current instanceof ShadowRoot) {
+      current = (current as ShadowRoot).host;
+    } else {
+      current = current.parentNode;
+    }
+  }
+
+  return document.documentElement.lang || 'nb';
+}

--- a/src/utilities/translations.ts
+++ b/src/utilities/translations.ts
@@ -1,0 +1,101 @@
+/**
+ * All UI strings that components render themselves (e.g. aria-labels on
+ * icon-only buttons). Every supported language must provide all keys.
+ */
+export interface ComponentTranslations {
+  /** aria-label for the clear/reset button */
+  clear: string;
+  /** aria-label for the "show password" toggle button */
+  showPassword: string;
+  /** aria-label for the "hide password" toggle button */
+  hidePassword: string;
+}
+
+// ---------------------------------------------------------------------------
+// Built-in defaults
+// ---------------------------------------------------------------------------
+
+const builtins: Record<string, ComponentTranslations> = {
+  nb: {
+    clear: 'Tøm',
+    showPassword: 'Vis passord',
+    hidePassword: 'Skjul passord',
+  },
+  nn: {
+    clear: 'Tøm',
+    showPassword: 'Vis passord',
+    hidePassword: 'Gøym passord',
+  },
+  se: {
+    clear: 'Sihko',
+    showPassword: 'Čájet sátnesuodji',
+    hidePassword: 'Čiehka sátnesuodji',
+  },
+  en: {
+    clear: 'Clear',
+    showPassword: 'Show password',
+    hidePassword: 'Hide password',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+const registry = new Map<string, ComponentTranslations>(
+  Object.entries(builtins)
+);
+
+/**
+ * Override or extend translations for a given BCP-47 language tag.
+ * Merges the provided strings with the existing entry for that tag, so you
+ * only need to supply the keys you want to change.
+ *
+ * Call this once at app startup, before any components render.
+ *
+ * @example Override a single string for Norwegian Bokmål
+ * ```ts
+ * setTranslations('nb', { clear: 'Slett' });
+ * ```
+ *
+ * @example Register a completely new language
+ * ```ts
+ * setTranslations('fr', {
+ *   clear: 'Effacer',
+ *   showPassword: 'Afficher le mot de passe',
+ *   hidePassword: 'Masquer le mot de passe',
+ * });
+ * ```
+ */
+export function setTranslations(
+  lang: string,
+  translations: Partial<ComponentTranslations>
+): void {
+  const base = resolveBaseLang(lang);
+  const existing = registry.get(lang) ?? registry.get(base) ?? builtins.nb;
+  registry.set(lang, { ...existing, ...translations });
+}
+
+// ---------------------------------------------------------------------------
+// Lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the translations for the given BCP-47 language tag.
+ *
+ * Resolution order:
+ *   1. Exact tag match (e.g. `'nb-NO'`)
+ *   2. Base language match (e.g. `'nb'` from `'nb-NO'`)
+ *   3. Norwegian Bokmål as final fallback
+ */
+export function getTranslations(lang: string): ComponentTranslations {
+  return (
+    registry.get(lang) ??
+    registry.get(resolveBaseLang(lang)) ??
+    builtins.nb
+  );
+}
+
+function resolveBaseLang(lang: string): string {
+  return lang.toLowerCase().split('-')[0];
+}

--- a/src/utilities/translations.ts
+++ b/src/utilities/translations.ts
@@ -3,17 +3,11 @@
  * icon-only buttons). Every supported language must provide all keys.
  */
 export interface ComponentTranslations {
-  /** aria-label for the clear/reset button */
   clear: string;
-  /** aria-label for the "show password" toggle button */
   showPassword: string;
-  /** aria-label for the "hide password" toggle button */
   hidePassword: string;
 }
 
-// ---------------------------------------------------------------------------
-// Built-in defaults
-// ---------------------------------------------------------------------------
 
 const builtins: Record<string, ComponentTranslations> = {
   nb: {
@@ -37,10 +31,6 @@ const builtins: Record<string, ComponentTranslations> = {
     hidePassword: 'Hide password',
   },
 };
-
-// ---------------------------------------------------------------------------
-// Registry
-// ---------------------------------------------------------------------------
 
 const registry = new Map<string, ComponentTranslations>(
   Object.entries(builtins)
@@ -75,10 +65,6 @@ export function setTranslations(
   const existing = registry.get(lang) ?? registry.get(base) ?? builtins.nb;
   registry.set(lang, { ...existing, ...translations });
 }
-
-// ---------------------------------------------------------------------------
-// Lookup
-// ---------------------------------------------------------------------------
 
 /**
  * Returns the translations for the given BCP-47 language tag.


### PR DESCRIPTION
## Fix
 - Fix textfield so text inside dont disapear when user move focus
 - Use DS affix to correctly place the clear and show password button (Update icon for clear text from xmark to trash can)
 - Added translation for elements like show password
   - Consumers can also add their own language and overwrite

## changesets
- Will fix changesets later

## Images of the new affix
<img width="482" height="120" alt="image" src="https://github.com/user-attachments/assets/50693103-648a-4fd9-9696-e43c8fe75de4" />
<img width="583" height="380" alt="image" src="https://github.com/user-attachments/assets/8fd77eaf-b579-435b-89cb-b40b57bcbe72" />
