### PR TITLE
Small fixes

### DIFF
--- a/.changeset/swift-bears-wake.md
+++ b/.changeset/swift-bears-wake.md
@@ -1,0 +1,11 @@
+---
+'@felleslosninger/minid-elements': patch
+---
+
+Add alertdialog support to `mid-dialog`; add type mismatch validation to `mid-textfield`
+
+### Fixes and improvements
+
+- `mid-dialog` has a new `alertdialog` boolean attribute that switches the dialog role to `alertdialog` and focuses it on open, for blocking dialogs requiring immediate user attention
+- `mid-dialog` close button now has a translated `aria-label` in all supported languages (nb, nn, se, en)
+- `mid-textfield` now validates `email` and `url` input types using a `typeMismatchValidator`, surfacing native browser type-mismatch errors through the component's validation API

--- a/src/components/dialog.component.ts
+++ b/src/components/dialog.component.ts
@@ -1,5 +1,8 @@
-import { css, html, LitElement } from 'lit';
+import { css, html, LitElement, nothing } from 'lit';
 import { customElement, property, query } from 'lit/decorators.js';
+import { getLang } from '../utilities/lang';
+import { getTranslations } from '../utilities/translations';
+import { LangController } from '../controllers/lang.controller.js';
 import { waitForEvent } from '../internal/event';
 import { watch } from '../internal/watch';
 import { styled } from '../mixins/tailwind.mixin';
@@ -70,6 +73,13 @@ export class MinidDialog extends styled(LitElement, styles) {
   @property({ reflect: true })
   heading = '';
 
+  /**
+   * When set, the dialog uses `role="alertdialog"` instead of `role="dialog"`, signalling urgency to screen readers.
+   * Use this for blocking dialogs that require immediate user attention.
+   */
+  @property({ type: Boolean, reflect: true })
+  alertdialog = false;
+
   private requestClose(source: 'close-button' | 'keyboard' | 'overlay') {
     const requestCloseEvent = new CustomEvent('mid-request-close', {
       bubbles: true,
@@ -114,6 +124,10 @@ export class MinidDialog extends styled(LitElement, styles) {
       );
       // this.addOpenListeners();
       this.dialog.showModal();
+
+      if (this.alertdialog) {
+        this.dialog.focus();
+      }
 
       lockBodyScrolling(this);
 
@@ -177,11 +191,22 @@ export class MinidDialog extends styled(LitElement, styles) {
     return waitForEvent(this, 'mid-after-hide');
   }
 
+  constructor() {
+    super();
+    new LangController(this);
+  }
+
   override render() {
+    const t = getTranslations(getLang(this));
+
     return html`
       <dialog
         part="base"
         id="dialog"
+        tabindex="-1"
+        role=${this.alertdialog ? 'alertdialog' : 'dialog'}
+        aria-label=${this.heading || nothing}
+        aria-modal="true"
         class="text-neutral m-auto max-h-[calc(100%---spacing(8))] w-(--width) max-w-[calc(100%---spacing(8))] flex-col rounded-lg p-6 shadow-xl backdrop:bg-black/50 open:flex open:animate-none"
         @cancel=${this.handleDialogCancel}
         @click=${this.handleBackdropClick}
@@ -191,6 +216,7 @@ export class MinidDialog extends styled(LitElement, styles) {
           <div class="h-0">
             <button
               autofocus
+              aria-label=${t.close}
               @click="${() => this.requestClose('close-button')}"
               class="text-body-md focus-visible:focus-ring text-neutral hover:bg-neutral-surface-hover float-right flex size-12 translate-x-3 -translate-y-3 items-center justify-center rounded"
             >

--- a/src/components/textfield.component.ts
+++ b/src/components/textfield.component.ts
@@ -1,4 +1,4 @@
-import { css, html, LitElement, nothing } from 'lit';
+import { css, html, LitElement, nothing, type PropertyValues } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
 import { live } from 'lit/directives/live.js';
 import { stringConverter } from '../internal/string-converter';
@@ -12,6 +12,7 @@ import {
   minLengthValidator,
   patternValidator,
   requiredValidator,
+  typeMismatchValidator,
 } from '../mixins/validators';
 import { watch } from '../internal/watch';
 import './icon/icon.component.ts';
@@ -230,6 +231,7 @@ export class MinidTextfield extends FormControlMixin(styled(LitElement, styles))
       maxLengthValidator,
       minLengthValidator,
       patternValidator,
+      typeMismatchValidator,
     ];
   }
 
@@ -246,6 +248,15 @@ export class MinidTextfield extends FormControlMixin(styled(LitElement, styles))
   override connectedCallback(): void {
     super.connectedCallback();
     this.initialValue = this.value;
+  }
+
+  get validationTarget() {
+    return this.input;
+  }
+
+  protected firstUpdated(_changedProperties: PropertyValues): void {
+    super.firstUpdated(_changedProperties);
+    this.setValue(this.value);
   }
 
   disconnectedCallback(): void {

--- a/src/mixins/validators.ts
+++ b/src/mixins/validators.ts
@@ -88,3 +88,30 @@ export const patternValidator: Validator = {
     return !!regExp.exec(value);
   },
 };
+
+export const typeMismatchValidator: Validator = {
+  attribute: 'type',
+  key: 'typeMismatch',
+  message(instance: HTMLElement & { input?: HTMLInputElement }): string {
+    return instance.input?.validationMessage || 'Please enter a valid value';
+  },
+  isValid(
+    instance: HTMLElement & { type?: HTMLInputElement['type'] },
+    value: FormValue
+  ): boolean {
+    if (
+      !value ||
+      typeof value !== 'string' ||
+      (instance.type !== 'email' && instance.type !== 'url') ||
+      typeof document === 'undefined'
+    ) {
+      return true;
+    }
+
+    const input = document.createElement('input');
+    input.type = instance.type;
+    input.value = value;
+
+    return !input.validity.typeMismatch;
+  },
+};

--- a/src/stories/Dialog.stories.ts
+++ b/src/stories/Dialog.stories.ts
@@ -6,6 +6,7 @@ import '../components/paragraph.component';
 
 type DialogProps = Partial<{
   open: boolean;
+  alertdialog: boolean;
   'mid-show': Event;
   'mid-hide': Event;
   'mid-after-show': Event;
@@ -27,6 +28,10 @@ const meta = {
   title: 'Komponenter/Dialog',
   component: 'mid-dialog',
   argTypes: {
+    alertdialog: {
+      control: { type: 'boolean' },
+      description: 'When set, uses `role="alertdialog"` for urgent blocking dialogs that require immediate attention.',
+    },
     'mid-request-close': {
       control: { type: 'select' },
       options: ['preventDefault', 'normal'],
@@ -67,10 +72,43 @@ type Story = StoryObj<DialogProps>;
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 
+export const AlertDialog: Story = {
+  args: { open: true, alertdialog: true },
+  render: ({ 'mid-request-close': requestClose }: DialogProps) => {
+    return html`
+      <mid-button class="dialog-button">Åpne varsel-dialog</mid-button>
+      <mid-dialog
+        open
+        alertdialog
+        class="dialog"
+        @mid-request-close=${(event: Event) =>
+          requestClose === 'preventDefault' && event.preventDefault()}
+      >
+        <h2 class="mb-2" slot="heading">Tidsfristen har gått ut</h2>
+        <mid-paragraph spacing>
+          Du har gått tom for tid og må starte prosessen på nytt.
+        </mid-paragraph>
+        <div slot="footer" class="flex flex-row-reverse gap-4 self-stretch justify-self-end">
+          <mid-button class="confirm-button">Gå til start</mid-button>
+        </div>
+      </mid-dialog>
+      <script>
+        var dialogButton = document.querySelector('.dialog-button');
+        var dialog = document.querySelector('.dialog');
+        var confirmButton = document.querySelector('.confirm-button');
+
+        dialogButton.addEventListener('click', () => dialog.show());
+        confirmButton.addEventListener('click', () => dialog.hide());
+      </script>
+    `;
+  },
+};
+
 export const Main: Story = {
   args: {},
   render: ({
     open,
+    alertdialog,
     footerSlot,
     heading,
     'mid-request-close': requestClose,
@@ -80,6 +118,7 @@ export const Main: Story = {
       <mid-button class="dialog-button">Dialog</mid-button>
       <mid-dialog
         ?open=${open}
+        ?alertdialog=${alertdialog}
         class="dialog"
         @mid-request-close=${(event: Event) =>
           requestClose === 'preventDefault' && event.preventDefault()}

--- a/src/utilities/translations.ts
+++ b/src/utilities/translations.ts
@@ -7,6 +7,7 @@ export interface ComponentTranslations {
   showPassword: string;
   hidePassword: string;
   openCountrySelector: string;
+  close: string;
 }
 
 
@@ -16,24 +17,28 @@ const builtins: Record<string, ComponentTranslations> = {
     showPassword: 'Vis passord',
     hidePassword: 'Skjul passord',
     openCountrySelector: 'Åpne landsvelger',
+    close: 'Lukk',
   },
   nn: {
     clear: 'Tøm',
     showPassword: 'Vis passord',
     hidePassword: 'Gøym passord',
     openCountrySelector: 'Opna landsveljar',
+    close: 'Lukk',
   },
   se: {
     clear: 'Sihko',
     showPassword: 'Čájet sátnesuodji',
     hidePassword: 'Čiehka sátnesuodji',
     openCountrySelector: 'Rahpat riikkaválljenjoavkku',
+    close: 'Gidde',
   },
   en: {
     clear: 'Clear',
     showPassword: 'Show password',
     hidePassword: 'Hide password',
     openCountrySelector: 'Open country selector',
+    close: 'Close',
   },
 };
 


### PR DESCRIPTION
### Fixes and improvements

- `mid-dialog` has a new `alertdialog` boolean attribute that switches the dialog role to `alertdialog` and focuses it on open, for blocking dialogs requiring immediate user attention
- `mid-dialog` close button now has a translated `aria-label` in all supported languages (nb, nn, se, en)
- `mid-textfield` now validates `email` and `url` input types using a `typeMismatchValidator`, surfacing native browser type-mismatch errors through the component's validation API
