### PR TITLE
Added language selector

### DIFF
--- a/.changeset/add-language-selector.md
+++ b/.changeset/add-language-selector.md
@@ -1,0 +1,5 @@
+---
+'@felleslosninger/minid-elements': patch
+---
+
+Add `mid-language-selector` component for locale switching, using Designsystemet dropdown styling

--- a/package.json
+++ b/package.json
@@ -88,6 +88,10 @@
       "import": "./dist/components/label.js",
       "types": "./dist/components/label.component.d.ts"
     },
+    "./language-selector": {
+      "import": "./dist/components/language-selector.js",
+      "types": "./dist/components/language-selector.component.d.ts"
+    },
     "./link": {
       "import": "./dist/components/link.js",
       "types": "./dist/components/link.component.d.ts"

--- a/src/components/language-selector.component.ts
+++ b/src/components/language-selector.component.ts
@@ -1,0 +1,170 @@
+import { css, html, LitElement, nothing } from 'lit';
+import { customElement, property, query, state } from 'lit/decorators.js';
+import { styled } from '../mixins/tailwind.mixin.ts';
+import './icon/icon.component.ts';
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'mid-language-selector': MinidLanguageSelector;
+  }
+}
+
+let nextUniqueId = 0;
+
+const styles = [
+  css`
+    :host {
+      display: inline-flex;
+      position: relative;
+    }
+    button > mid-icon {
+      font-size: 2rem;
+    }
+    .panel {
+      position: absolute;
+      inset: auto;
+      inset-inline-end: 0;
+      top: 100%;
+      margin-block-start: 4px;
+      z-index: 10;
+      min-width: 10rem;
+    }
+    .panel li button {
+      text-align: start;
+    }
+    .panel li button:hover,
+    .panel li button:focus {
+      background-color: var(--ds-color-neutral-surface-hover);
+    }
+  `,
+];
+
+@customElement('mid-language-selector')
+export class MinidLanguageSelector extends styled(LitElement, styles) {
+  private readonly _panelId = `mid-lang-${nextUniqueId++}`;
+
+  @state() private _open = false;
+
+  @property()
+  locale: string = 'nb';
+
+  @property({ type: Object })
+  languages: Record<string, string> = {
+    nb: 'Bokmål',
+    nn: 'Nynorsk',
+    en: 'English',
+    se: 'Sámegiella',
+  };
+
+  private _handleDocumentMouseDown = (e: MouseEvent) => {
+    if (!e.composedPath().includes(this)) {
+      this._close();
+    }
+  };
+
+  private _handleDocumentKeyDown = (e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation();
+      this._close();
+      this._triggerEl?.focus();
+    }
+  };
+
+  @query('button')
+  private _triggerEl?: HTMLButtonElement;
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._removeListeners();
+  }
+
+  private _addListeners() {
+    document.addEventListener('mousedown', this._handleDocumentMouseDown, true);
+    document.addEventListener('keydown', this._handleDocumentKeyDown, true);
+  }
+
+  private _removeListeners() {
+    document.removeEventListener(
+      'mousedown',
+      this._handleDocumentMouseDown,
+      true,
+    );
+    document.removeEventListener(
+      'keydown',
+      this._handleDocumentKeyDown,
+      true,
+    );
+  }
+
+  private _toggle() {
+    if (this._open) {
+      this._close();
+    } else {
+      this._open = true;
+      this._addListeners();
+    }
+  }
+
+  private _close() {
+    this._open = false;
+    this._removeListeners();
+  }
+
+  private _select(locale: string) {
+    this.dispatchEvent(
+      new CustomEvent('mid-language-change', {
+        detail: { locale },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    this._close();
+    this._triggerEl?.focus();
+  }
+
+  override render() {
+    return html`
+      <button
+        class="focus-visible:focus-ring flex h-fit min-h-12 cursor-pointer items-center gap-2 rounded border border-transparent bg-transparent px-4 py-2 font-medium text-accent-subtle hover:bg-accent-surface-hover hover:text-accent active:bg-accent-surface-active"
+        aria-expanded=${this._open}
+        aria-controls=${this._panelId}
+        @click=${this._toggle}
+      >
+        <mid-icon name="language"></mid-icon>
+        <span class="max-md:sr-only">Language</span>
+        <mid-icon
+          name="chevron-down"
+          class="max-md:hidden"
+          aria-hidden="true"
+        ></mid-icon>
+      </button>
+
+      ${this._open
+        ? html`
+            <div
+              id=${this._panelId}
+              class="ds-dropdown panel"
+              role="group"
+              aria-label="Select language"
+            >
+              <ul>
+                ${Object.entries(this.languages).map(
+                  ([key, name]) => html`
+                    <li>
+                      <button
+                        lang=${key}
+                        aria-current=${key === this.locale ? 'true' : nothing}
+                        @click=${() => this._select(key)}
+                      >
+                        ${name}
+                      </button>
+                    </li>
+                  `,
+                )}
+              </ul>
+            </div>
+          `
+        : nothing}
+    `;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export { MinidHeading } from './components/heading.component.ts';
 export { MinidHelptext } from './components/helptext.component.ts';
 export { MinidIcon } from './components/icon/icon.component.ts';
 export { MinidLabel } from './components/label.component.ts';
+export { MinidLanguageSelector } from './components/language-selector.component.ts';
 export { MinidLink } from './components/link.component.ts';
 export { MinidMenu } from './components/menu.component.ts';
 export { MinidMenuItem } from './components/menu-item.component.ts';

--- a/src/stories/LanguageSelector.stories.ts
+++ b/src/stories/LanguageSelector.stories.ts
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/web-components-vite';
+import { html } from 'lit';
+import '../components/language-selector.component';
+import { MinidLanguageSelector } from '../components/language-selector.component';
+
+type LanguageSelectorProps = Partial<{
+  locale: MinidLanguageSelector['locale'];
+  languages: MinidLanguageSelector['languages'];
+  change: (event: CustomEvent<{ locale: string }>) => void;
+}>;
+
+const meta = {
+  title: 'Komponenter/LanguageSelector',
+  tags: ['autodocs'],
+  component: 'mid-language-selector',
+  argTypes: {
+    locale: {
+      control: { type: 'radio' },
+      options: ['nb', 'nn', 'en', 'se'],
+    },
+    languages: {
+      control: { disable: true },
+    },
+  },
+  args: {
+    locale: 'nb',
+    change: ({ detail: { locale } }) => {
+      console.log('Language changed to:', locale);
+    },
+  },
+  parameters: {
+    controls: {
+      exclude: ['change'],
+    },
+  },
+} satisfies Meta<LanguageSelectorProps>;
+
+export default meta;
+type Story = StoryObj<LanguageSelectorProps>;
+
+export const Default: Story = {
+  decorators: [(story) => html`<div class="m-56">${story()}</div>`],
+  parameters: {
+    layout: 'centered',
+  },
+  render: ({ locale, change }: LanguageSelectorProps) => html`
+    <mid-language-selector
+      locale=${locale ?? 'nb'}
+      @mid-language-change=${change}
+    ></mid-language-selector>
+  `,
+};
+
+export const Mobile: Story = {
+  decorators: [
+    (story) =>
+      html`<div class="m-56" style="width: 60px">${story()}</div>`,
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+  render: ({ locale, change }: LanguageSelectorProps) => html`
+    <mid-language-selector
+      locale=${locale ?? 'nb'}
+      @mid-language-change=${change}
+    ></mid-language-selector>
+  `,
+};


### PR DESCRIPTION
Add `mid-language-selector` component for locale switching, using Designsystemet dropdown styling

<img width="253" height="283" alt="image" src="https://github.com/user-attachments/assets/9c0a7122-6eae-410e-9d6d-eccf6e7744f8" />
