### PR TITLE
Fix CSP violation for alert, and paring checkbox input to label.

### DIFF
--- a/.changeset/fix-alert-csp-checkbox-label.md
+++ b/.changeset/fix-alert-csp-checkbox-label.md
@@ -1,0 +1,5 @@
+---
+"@felleslosninger/minid-elements": patch
+---
+
+Replace inline styles in `mid-alert` with Tailwind utility classes to fix CSP violations. Add `id`/`for` pairing to `mid-checkbox` input and label for correct accessibility.

--- a/src/components/alert.component.ts
+++ b/src/components/alert.component.ts
@@ -291,7 +291,7 @@ export class MinidAlert extends styled(LitElement) {
         @mouseenter=${this.pauseAutoHide}
         @mouseleave=${this.resumeAutoHide}
       >
-        <div style="display: grid; grid-template-columns: 1fr ${this.closable ? 'auto' : ''};">
+        <div class="${classMap({ 'grid-cols-[1fr_auto]': this.closable })} grid">
           <div aria-live="${this.arialive}">
             <slot>
               ${!this.notificationContent?.title
@@ -332,8 +332,7 @@ ${this.notificationContent?.details}</pre
                     'hover:bg-info-surface-hover': info,
                     'hover:bg-success-surface-hover': success,
                     'hover:bg-warning-surface-hover': warning,
-                  })} flex rounded p-2"
-                  style="align-self: start; justify-self: end;"
+                  })} flex rounded p-2 self-start justify-self-end"
                   @click="${this.hide}"
                   aria-label="Dismiss alert"
                 >

--- a/src/components/checkbox.component.ts
+++ b/src/components/checkbox.component.ts
@@ -124,6 +124,7 @@ export class MinidCheckbox extends FormControlMixin(styled(LitElement)) {
     return html`
       <ds-field class="ds-field">
       <input
+      id="input"
       class="ds-input"
       type="checkbox"
       value=${ifDefined(this.value)}
@@ -138,6 +139,7 @@ export class MinidCheckbox extends FormControlMixin(styled(LitElement)) {
         <label
           class="ds-label"
           part="label"
+          for="input"
         >
           <slot></slot>
         </label>


### PR DESCRIPTION
Replace inline styles in `mid-alert` with Tailwind utility classes to fix CSP violations. Add `id`/`for` pairing to `mid-checkbox` input and label for correct accessibility.